### PR TITLE
bolded username leads to indented chat messages on Mac devices and some FF

### DIFF
--- a/labs/meteor-client/app/client/views/chat/chat_bar.html
+++ b/labs/meteor-client/app/client/views/chat/chat_bar.html
@@ -58,7 +58,7 @@
     <span style="float:left;">
         {{#if message.from_username}}
             <span class="userNameEntry" rel="tooltip" data-placement="bottom" title="{{message.from_username}}">
-                <strong>{{message.from_username}}</strong>
+                {{message.from_username}}
             </span>
         {{/if}}
     </span>


### PR DESCRIPTION
Removing the bolding of the username did the job. The username is different color so it still stands out. Adding <br/> instead of removing the bolding resulted in additional vertical spreading of the message block which looked off. Yet to test the change on an Apple device. FF looks fine