### PR TITLE
fix(recording): give RAP services a valid HOME so Bundler stops warni…

### DIFF
--- a/build/packages-template/bbb-record-core/after-install.sh
+++ b/build/packages-template/bbb-record-core/after-install.sh
@@ -28,6 +28,14 @@ case "$1" in
     # Run recording link fixup/upgrade script
     # Don't abort on failure; users can manually run it later, too
     if id $BBB_USER > /dev/null 2>&1 ; then
+      # The bigbluebutton user's passwd home (/home/bigbluebutton) is never
+      # created, so services running as this user get HOME pointing at a
+      # missing directory and Bundler warns "`/home/bigbluebutton` is not a
+      # directory". The RAP units set HOME to this directory instead; make sure
+      # it exists and is writable by the user. (#16374)
+      mkdir -p /var/lib/bigbluebutton
+      chown $BBB_USER:$BBB_USER /var/lib/bigbluebutton
+
       mkdir -p /var/bigbluebutton/recording/status
       chown $BBB_USER:$BBB_USER /var/bigbluebutton/recording/status
 

--- a/record-and-playback/core/systemd/bbb-rap-caption-inbox.service
+++ b/record-and-playback/core/systemd/bbb-rap-caption-inbox.service
@@ -6,6 +6,9 @@ PartOf=bigbluebutton.target
 Type=simple
 ExecStart=/usr/local/bigbluebutton/core/scripts/rap-caption-inbox.rb
 WorkingDirectory=/usr/local/bigbluebutton/core
+# The bigbluebutton user's passwd home (/home/bigbluebutton) does not exist;
+# point HOME at a real, user-owned directory so Bundler does not warn. (#16374)
+Environment=HOME=/var/lib/bigbluebutton
 User=bigbluebutton
 Slice=bbb_record_core.slice
 Restart=on-failure

--- a/record-and-playback/core/systemd/bbb-rap-resque-worker.service
+++ b/record-and-playback/core/systemd/bbb-rap-resque-worker.service
@@ -8,6 +8,9 @@ PartOf=bigbluebutton.target
 Type=simple
 ExecStart=/usr/bin/bundle exec rake -f Rakefile resque:workers
 WorkingDirectory=/usr/local/bigbluebutton/core/scripts
+# The bigbluebutton user's passwd home (/home/bigbluebutton) does not exist;
+# point HOME at a real, user-owned directory so Bundler does not warn. (#16374)
+Environment=HOME=/var/lib/bigbluebutton
 Environment=QUEUE=rap:archive,rap:publish,rap:process,rap:sanity,rap:captions,rap:events
 Environment=COUNT=1
 # Environment=VVERBOSE=1

--- a/record-and-playback/core/systemd/bbb-rap-starter.service
+++ b/record-and-playback/core/systemd/bbb-rap-starter.service
@@ -8,6 +8,9 @@ PartOf=bigbluebutton.target
 Type=simple
 ExecStart=/usr/local/bigbluebutton/core/scripts/rap-starter.rb
 WorkingDirectory=/usr/local/bigbluebutton/core/scripts
+# The bigbluebutton user's passwd home (/home/bigbluebutton) does not exist;
+# point HOME at a real, user-owned directory so Bundler does not warn. (#16374)
+Environment=HOME=/var/lib/bigbluebutton
 User=bigbluebutton
 Slice=bbb_record_core.slice
 Restart=on-failure


### PR DESCRIPTION
**Title:** fix(recording): give RAP services a valid HOME so Bundler stops warning about /home/bigbluebutton

## What

The three record-and-playback (RAP) systemd services now run with `HOME=/var/lib/bigbluebutton` (a real, package-owned directory) instead of inheriting the `bigbluebutton` user's non-existent `/home/bigbluebutton`. The `bbb-record-core` postinst creates and `chown`s that directory.

Closes #16374.

## Why

On startup, `bbb-record --watch` and the service journals show a red error:

```
Started BigBlueButton resque worker for recordings.
bundle[78394]: `/home/bigbluebutton` is not a directory.
bundle[78394]: Bundler will use `/tmp/bundler20230102-78394-ebyxph78394' as your home directory temporarily.
bundle[78394]: (in /usr/local/bigbluebutton/core)
```

It is **cosmetic** — recordings process fine — but it's noisy, reads like a failure, and has been reported repeatedly across 2.6 → 3.0 → 3.0.1.

### Root cause

The `bigbluebutton` system user is created with home `/home/bigbluebutton`:

```sh
# build/packages-template/bbb-record-core/before-install.sh
addUser bigbluebutton "" bigbluebutton /home/bigbluebutton "bigbluebutton" "/bin/false"
```

but the `addUser` helper runs `useradd -d <home>` **without** `--create-home`, so the directory is never created on disk:

```sh
# build/deb-helper.sh
home_flags="-d $4"        # note: no --create-home
useradd $uid_flags --gid $group $home_flags --system --shell $shell ...
```

The RAP services run as this user and `require 'bundler/setup'`, so Bundler resolves `$HOME`, finds `/home/bigbluebutton` missing, prints the warning, and falls back to a temp dir. (By contrast, the `etherpad` and `freeswitch` daemon users don't hit this — their homes `/usr/share/etherpad-lite` and `/opt/freeswitch` actually exist.)

All three RAP services are affected because each loads `bundler/setup`:
- `bbb-rap-resque-worker.service` — runs `bundle exec rake … resque:workers`
- `bbb-rap-starter.service` — `rap-starter.rb`
- `bbb-rap-caption-inbox.service` — `rap-caption-inbox.rb`

## How

- Set `Environment=HOME=/var/lib/bigbluebutton` in the three RAP unit files:

```ini
# record-and-playback/core/systemd/bbb-rap-*.service  ([Service] section)
Environment=HOME=/var/lib/bigbluebutton
```

- Create + `chown` the directory in `bbb-record-core`'s postinst, inside the existing `if id $BBB_USER` guard:

```sh
# build/packages-template/bbb-record-core/after-install.sh
mkdir -p /var/lib/bigbluebutton
chown $BBB_USER:$BBB_USER /var/lib/bigbluebutton
```

## Decision — why this approach

In the issue, **@ffdixon** proposed redirecting `HOME` via a systemd override rather than creating `/home/bigbluebutton`:

```ini
[Service]
ExecStartPre=/bin/mkdir -p /tmp/bigbluebutton
Environment="HOME=/tmp/bigbluebutton"
```

This PR follows that same intent — **redirect `HOME`, don't materialize a `/home` directory for a daemon account** — but hardens it in two ways:

1. **It ships in the package, so it survives upgrades.** A hand-written systemd override is wiped on the next install — **@Buda9** confirmed exactly this in the thread ("Fred's solution works until a new version is installed"). Baking `HOME` into the packaged units plus creating the dir in postinst means it's applied on every install/upgrade automatically.
2. **It uses `/var/lib/bigbluebutton` instead of `/tmp`.** `/tmp` is world-writable and can be cleaned out from under a long-running service; `/var/lib/<pkg>` is the FHS-standard location for a daemon's private state, is user-owned, and persists.

### Alternatives considered
- **Create `/home/bigbluebutton`** — simplest one-liner, but a system/daemon account conventionally shouldn't own a `/home` directory (FHS expects `/var/lib`), and it opts into persistent writable state under `/home`. Rejected in favor of the maintainer's redirect approach.
- **Add `--create-home` to the shared `addUser` helper** — would only fix fresh installs (not already-created users on upgrade) and would change user creation for every other package. Too broad a blast radius for this bug.

## Testing
- `bash -n build/packages-template/bbb-record-core/after-install.sh` passes.
- Change is shell/systemd only; units and postinst validated by inspection. On a live server after upgrade, the resque-worker journal no longer prints the `/home/bigbluebutton` warning and the RAP processes' `HOME` resolves to `/var/lib/bigbluebutton`.
