### PR TITLE
Fix 21125

### DIFF
--- a/docs/docs/administration/configuration-files.md
+++ b/docs/docs/administration/configuration-files.md
@@ -32,8 +32,9 @@ Starting with BigBlueButton 2.3 many of the configuration files have local overr
 | /usr/local/bigbluebutton/bbb-webrtc-sfu/config/default.yml              | /etc/bigbluebutton/bbb-webrtc-sfu/production.yml | Arrays are merged by replacement                                                 |
 | /usr/local/bigbluebutton/bbb-pads/config/settings.json                  | /etc/bigbluebutton/bbb-pads.json                 | Arrays are merged by replacement                                                 |
 | /usr/share/bbb-shared-notes-server/config/default.yml                   | /etc/bigbluebutton/bbb-shared-notes-server.yml   |                                                  |
-| /usr/local/bigbluebutton/core/scripts/bigbluebutton.yml                 | /etc/bigbluebutton/recording/recording.yml       |
+| /usr/local/bigbluebutton/core/scripts/bigbluebutton.yml                 | /etc/bigbluebutton/recording/recording.yml       | Honored by all recording formats; re-read on every processing step, so changes do not require a restart |
 | /usr/local/bigbluebutton/core/scripts/presentation.yml                  | /etc/bigbluebutton/recording/presentation.yml    |
+| /usr/local/bigbluebutton/core/scripts/video.yml                         | /etc/bigbluebutton/recording/video.yml           | Individual `presets` are merged by key; other settings are replaced              |
 | /etc/cron.daily/bigbluebutton                                           | /etc/default/bigbluebutton-cron-config    | Only variables allowed in the override
 
 <br /><br />
@@ -65,6 +66,15 @@ services {
   sharedSecret="UsanRxRk938d02cTWfAqSM9Cvin7bnzsREfqFfzpf2U"
 }
 ```
+
+For the recording pipeline, `/etc/bigbluebutton/recording/recording.yml` overrides settings from `/usr/local/bigbluebutton/core/scripts/bigbluebutton.yml` for every recording format (presentation, video, screenshare, notes, podcast). For example, the following `recording.yml` makes published recording links use a different hostname and protocol:
+
+```yml
+playback_host: playback.example.com
+playback_protocol: https
+```
+
+The override is re-read on every recording processing step, so a change takes effect for the next recording without restarting the recording workers. The playback link in a recording's `metadata.xml` is regenerated at publish time, so links of an already-published recording can be corrected by rebuilding it: `bbb-record --rebuild <internal meeting ID>`.
 
 ## HTML5 Client
 

--- a/record-and-playback/core/lib/recordandplayback.rb
+++ b/record-and-playback/core/lib/recordandplayback.rb
@@ -237,19 +237,16 @@ module BigBlueButton
     File.join(BigBlueButton.rap_core_path, 'scripts')
   end
 
-  def self.read_props
-    return @props if @props
-
-    filepathRecOverride = "/etc/bigbluebutton/recording/recording.yml"
-    hasOverride = File.file?(filepathRecOverride)
-    
+  # Do not cache the result: long-lived processes (e.g. the resque workers)
+  # must pick up changes to the override file without a restart.
+  def self.read_props(override_path: '/etc/bigbluebutton/recording/recording.yml')
     filepath = File.join(BigBlueButton.rap_scripts_path, 'bigbluebutton.yml')
-    @props = YAML::load(File.open(filepath))
-    if (hasOverride)
-      recOverrideProps = YAML::load(File.open(filepathRecOverride))
-      @props = @props.merge(recOverrideProps)
+    props = YAML.safe_load(File.read(filepath), aliases: true) || {}
+    if File.file?(override_path)
+      override_props = YAML.safe_load(File.read(override_path), aliases: true) || {}
+      props = props.merge(override_props)
     end
-    @props
+    props
   end
 
   def self.create_redis_publisher

--- a/record-and-playback/core/test/recordandplayback/test_read_props.rb
+++ b/record-and-playback/core/test/recordandplayback/test_read_props.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+require 'minitest/autorun'
+require 'tmpdir'
+
+require 'recordandplayback'
+
+class TestReadProps < Minitest::Test
+  def test_returns_base_props_when_override_missing
+    props = BigBlueButton.read_props(override_path: '/nonexistent/recording.yml')
+
+    assert_kind_of(Hash, props)
+    refute_nil(props['playback_host'])
+  end
+
+  def test_override_merges_over_base_props
+    Dir.mktmpdir do |dir|
+      override = File.join(dir, 'recording.yml')
+      File.write(override, "playback_host: override.example.com\n")
+
+      props = BigBlueButton.read_props(override_path: override)
+
+      assert_equal('override.example.com', props['playback_host'])
+      refute_nil(props['recording_dir'])
+    end
+  end
+
+  def test_rereads_override_on_each_call
+    Dir.mktmpdir do |dir|
+      override = File.join(dir, 'recording.yml')
+
+      File.write(override, "playback_host: first.example.com\n")
+      assert_equal('first.example.com', BigBlueButton.read_props(override_path: override)['playback_host'])
+
+      File.write(override, "playback_host: second.example.com\n")
+      assert_equal('second.example.com', BigBlueButton.read_props(override_path: override)['playback_host'])
+    end
+  end
+
+  def test_empty_override_file_is_ignored
+    Dir.mktmpdir do |dir|
+      override = File.join(dir, 'recording.yml')
+      File.write(override, '')
+
+      props = BigBlueButton.read_props(override_path: override)
+
+      assert_kind_of(Hash, props)
+      refute_nil(props['playback_host'])
+    end
+  end
+end

--- a/record-and-playback/notes/scripts/process/notes.rb
+++ b/record-and-playback/notes/scripts/process/notes.rb
@@ -38,7 +38,7 @@ end
 meeting_id = opts[:meeting_id]
 
 # This script lives in scripts/archive/steps while properties.yaml lives in scripts/
-props = YAML::load(File.open('../../core/scripts/bigbluebutton.yml'))
+props = BigBlueButton.read_props
 notes_props = YAML::load(File.open('notes.yml'))
 format = notes_props['format']
 

--- a/record-and-playback/notes/scripts/publish/notes.rb
+++ b/record-and-playback/notes/scripts/publish/notes.rb
@@ -30,7 +30,7 @@ require 'fastimage' # require fastimage to get the image size of the slides (gem
 
 
 # This script lives in scripts/archive/steps while properties.yaml lives in scripts/
-bbb_props = YAML::load(File.open('../../core/scripts/bigbluebutton.yml'))
+bbb_props = BigBlueButton.read_props
 notes_props = YAML::load(File.open('notes.yml'))
 
 opts = Optimist::options do

--- a/record-and-playback/podcast/scripts/process/podcast.rb
+++ b/record-and-playback/podcast/scripts/process/podcast.rb
@@ -38,7 +38,7 @@ end
 meeting_id = opts[:meeting_id]
 
 # This script lives in scripts/archive/steps while properties.yaml lives in scripts/
-props = YAML::load(File.open('../../core/scripts/bigbluebutton.yml'))
+props = BigBlueButton.read_props
 podcast_props = YAML::load(File.open('podcast.yml'))
 
 recording_dir = props['recording_dir']

--- a/record-and-playback/podcast/scripts/publish/podcast.rb
+++ b/record-and-playback/podcast/scripts/publish/podcast.rb
@@ -30,7 +30,7 @@ require 'fastimage' # require fastimage to get the image size of the slides (gem
 
 
 # This script lives in scripts/archive/steps while properties.yaml lives in scripts/
-bbb_props = YAML::load(File.open('../../core/scripts/bigbluebutton.yml'))
+bbb_props = BigBlueButton.read_props
 podcast_props = YAML::load(File.open('podcast.yml'))
 
 opts = Optimist::options do

--- a/record-and-playback/screenshare/scripts/process/screenshare.rb
+++ b/record-and-playback/screenshare/scripts/process/screenshare.rb
@@ -40,7 +40,7 @@ begin
 end
 
 # Load parameters and set up paths
-props = YAML::load(File.open(File.expand_path('../../bigbluebutton.yml', __FILE__)))
+props = BigBlueButton.read_props
 screenshare_props = YAML::load(File.open(File.expand_path('../../screenshare.yml', __FILE__)))
 
 recording_dir = props['recording_dir']

--- a/record-and-playback/screenshare/scripts/publish/screenshare.rb
+++ b/record-and-playback/screenshare/scripts/publish/screenshare.rb
@@ -37,7 +37,7 @@ if playback != 'screenshare'
 end
 
 # Load parameters and set up paths
-props = YAML::load(File.open(File.expand_path('../../bigbluebutton.yml', __FILE__)))
+props = BigBlueButton.read_props
 screenshare_props = YAML::load(File.open(File.expand_path('../../screenshare.yml', __FILE__)))
 
 process_dir = "#{props['recording_dir']}/process/screenshare/#{meeting_id}"
@@ -81,8 +81,16 @@ captions.each do |caption|
                "#{publish_dir}/caption_#{caption['locale']}.vtt")
 end
 
-# Copy over metadata xml file
-FileUtils.cp("#{process_dir}/metadata.xml", "#{publish_dir}/metadata.xml")
+# Refresh the playback link from current props (honoring recording.yml
+# overrides) and write the updated metadata to the publish directory, rather
+# than copying the process-time metadata.xml with a possibly-stale link.
+metadata_xml = Nokogiri::XML(File.open("#{process_dir}/metadata.xml"))
+link = metadata_xml.at_xpath('/recording/playback/link')
+if link
+  link.content = "#{props['playback_protocol']}://#{props['playback_host']}/recording/screenshare/#{meeting_id}/"
+  logger.info "Refreshed playback link to #{link.content}"
+end
+File.write("#{publish_dir}/metadata.xml", metadata_xml.to_xml)
 
 # Copy over css and js support files
 FileUtils.cp_r("#{process_dir}/css", publish_dir)

--- a/record-and-playback/video/scripts/publish/video.rb
+++ b/record-and-playback/video/scripts/publish/video.rb
@@ -128,8 +128,15 @@ captions.each do |caption|
                "#{publish_dir}/caption_#{caption['locale']}.vtt")
 end
 
-# Copy over metadata xml file
-FileUtils.cp("#{process_dir}/metadata.xml", "#{publish_dir}/metadata.xml")
+# Refresh the playback link from current props (honoring recording.yml
+# overrides) and write the updated metadata to the publish directory, rather
+# than copying the process-time metadata.xml with a possibly-stale link.
+link = metadata_xml.at_xpath('/recording/playback/link')
+if link
+  link.content = "#{props['playback_protocol']}://#{props['playback_host']}/playback/video/#{meeting_id}/"
+  logger.info("Refreshed playback link to #{link.content}")
+end
+File.write("#{publish_dir}/metadata.xml", metadata_xml.to_xml)
 
 # Get raw size of presentation files
 raw_dir = "#{recording_dir}/raw/#{meeting_id}"


### PR DESCRIPTION
### What does this PR do?

Fixes recording playback links ignoring `/etc/bigbluebutton/recording/recording.yml` overrides (`playback_host` / `playback_protocol`), reported for bbb-playback-video in #21125 but actually affecting several formats, in three parts:

- **Formats bypassing the override**: the screenshare (process + publish), notes (process + publish) and podcast (process + publish) scripts loaded `bigbluebutton.yml` directly, so the override file was never consulted. They now load props via `BigBlueButton.read_props`, the same override-merging loader the presentation and video formats already use.
- **Stale links on publish**: the video and screenshare publish scripts copied the process-time `metadata.xml` verbatim, so a playback link baked in at process time was never refreshed — changing the override afterwards (and republishing) had no effect, forcing admins to hand-edit metadata files. The publish scripts now regenerate `<playback><link>` from current props at publish time, matching the presentation format.
- **Stale config in long-lived workers** (reworked from #25042, which targeted v3.0.x-develop): `read_props` cached its result in a module ivar, so the resque workers kept serving stale config until restarted. It now re-reads both files on every call, uses `YAML.safe_load` (with `aliases: true`), tolerates an empty override file (previously a `TypeError` crash), and takes the override path as a parameter for testability. A minitest covers merge precedence, per-call reload, and the empty/missing override cases.

Docs: `configuration-files.md` gains the `video.yml` override row, notes on the `recording.yml` row, and a `playback_host`/`playback_protocol` example including how to correct links of already-published recordings (`bbb-record --rebuild`).

### Closes Issue(s)

Closes #21125

### Motivation

Deployments that terminate TLS elsewhere or serve playback from a different hostname configure `playback_host`/`playback_protocol` in `recording.yml`, and integrations like Greenlight consume the link from `metadata.xml`. When formats bypass the override — or workers cache it — published links point at the wrong protocol/domain and every affected recording needs manual correction.

### How to test

1. Create `/etc/bigbluebutton/recording/recording.yml` with a distinctive `playback_host` (e.g. `playback.example.com`) and `playback_protocol: https`. Do **not** restart the recording workers.
2. Record a meeting and let the video (or screenshare/notes/podcast) format process and publish it.
3. Check `metadata.xml` in the published directory: `<link>` must use the override host/protocol.
4. Republish test (video/screenshare): change `playback_host` in `recording.yml`, remove the published dir and the `status/published/<id>-video.done` file, re-run the publish script only — the published link must reflect the new value without reprocessing.
5. Unit test: `cd record-and-playback/core && bundle exec ruby -Ilib test/recordandplayback/test_read_props.rb`.

Verified on a 4.0 (`v4.0.x-develop`) server: the previous direct-YAML load returns the non-override host while `read_props` returns the override; the publish-time refresh rewrites a stale process-time link to the current override URL for both video and screenshare link formats; and the new minitest passes (4 runs, 8 assertions) under the server's Ruby 3.2 bundle. All modified scripts pass `ruby -c`.

### More

- Supersedes #25042 (same author intent, rewritten and retargeted at v4.0.x-develop — can be closed if this merges).
- Out of scope: a few core utility scripts (`events_archiver.rb`, `rap-process-worker.rb`, caption utilities, `post_events` examples) still read `bigbluebutton.yml` directly; none of them build playback links.
- [x] Added/updated documentation

🤖 Generated with [Claude Code](https://claude.com/claude-code)
